### PR TITLE
updated 'Running API Umbrella', added link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In the API Umbrella stack, the Gatekeeper is represented below:
 
 ## Usage
 
-See [Running API Umbrella]() for setup instructions.
+See [Running API Umbrella](https://github.com/NREL/api-umbrella#running-api-umbrella) for setup instructions.
 
 ## Features
 


### PR DESCRIPTION
Added link on Running API Umbrella to https://github.com/NREL/api-umbrella#running-api-umbrella
