### PR TITLE
Implement new HTTPS requirement behavior

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -30,6 +30,7 @@ strip_cookies:
   - ^_ga$
   - ^is_returning$
 apiSettings:
+  require_https: required_return_error
   rate_limits:
     - duration: 1000
       accuracy: 500
@@ -112,3 +113,7 @@ apiSettings:
       status_code: 500
       code: INTERNAL_SERVER_ERROR
       message: An unexpected error has occurred. Try again later or contact us at {{baseUrl}}/contact for assistance
+    https_required:
+      status_code: 400
+      code: HTTPS_REQUIRED
+      message: "Requests must be made over HTTPS. Try accessing the API at: {{httpsUrl}}"

--- a/lib/gatekeeper/middleware.js
+++ b/lib/gatekeeper/middleware.js
@@ -5,6 +5,7 @@ module.exports.basicAuth = require('./middleware/basic_auth');
 module.exports.apiKeyValidator = require('./middleware/api_key_validator');
 module.exports.apiMatcher = require('./middleware/api_matcher');
 module.exports.apiSettings = require('./middleware/api_settings');
+module.exports.httpsRequirements = require('./middleware/https_requirements');
 module.exports.roleValdiator = require('./middleware/role_validator');
 module.exports.ipValidator = require('./middleware/ip_validator');
 module.exports.refererValidator = require('./middleware/referer_validator');

--- a/lib/gatekeeper/middleware/https_requirements.js
+++ b/lib/gatekeeper/middleware/https_requirements.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var _ = require('lodash'),
+    config = require('api-umbrella-config').global(),
+    url = require('url'),
     utils = require('../utils');
 
 var HttpsRequirements = function() {
@@ -9,6 +11,7 @@ var HttpsRequirements = function() {
 
 _.extend(HttpsRequirements.prototype, {
   initialize: function() {
+    this.httpsPort = config.get('https_port');
   },
 
   handleRequest: function(request, response, next) {
@@ -31,13 +34,21 @@ _.extend(HttpsRequirements.prototype, {
   },
 
   handleHttpRequest: function(mode, request, response, next) {
-    var url;
+    var httpUrl = request.base;
     if(request.apiUmbrellaGatekeeper && request.apiUmbrellaGatekeeper.originalUrl) {
-      url = request.apiUmbrellaGatekeeper.originalUrl;
+      httpUrl += request.apiUmbrellaGatekeeper.originalUrl;
     } else {
-      url = request.url;
+      httpUrl += request.url;
     }
-    var httpsUrl = request.base.replace(/^http:\/\//i, 'https://') + url;
+
+    var urlParts = url.parse(httpUrl);
+    urlParts.protocol = 'https:';
+    delete urlParts.port;
+    delete urlParts.host;
+    if(this.httpsPort && this.httpsPort !== 443) {
+      urlParts.port = this.httpsPort;
+    }
+    var httpsUrl = url.format(urlParts);
 
     if(mode === 'transition_return_error' || mode === 'transition_return_redirect') {
       var transitionStartAt = request.apiUmbrellaGatekeeper.settings.require_https_transition_start_at;

--- a/lib/gatekeeper/middleware/https_requirements.js
+++ b/lib/gatekeeper/middleware/https_requirements.js
@@ -1,0 +1,98 @@
+'use strict';
+
+var _ = require('lodash'),
+    utils = require('../utils');
+
+var HttpsRequirements = function() {
+  this.initialize.apply(this, arguments);
+};
+
+_.extend(HttpsRequirements.prototype, {
+  initialize: function() {
+  },
+
+  handleRequest: function(request, response, next) {
+    if(request.base.substring(0, 8).toLowerCase() === 'https://') {
+      // https requests are always okay, so continue.
+      next();
+    } else if(request.base.substring(0, 7).toLowerCase() !== 'http://') {
+      // If this isn't an http request, then we don't know how to handle it, so
+      // continue.
+      next();
+    } else {
+      var mode = request.apiUmbrellaGatekeeper.settings.require_https;
+      if(mode === 'optional') {
+        // Continue if https isn't required.
+        next();
+      } else {
+        this.handleHttpRequest(mode, request, response, next);
+      }
+    }
+  },
+
+  handleHttpRequest: function(mode, request, response, next) {
+    var url;
+    if(request.apiUmbrellaGatekeeper && request.apiUmbrellaGatekeeper.originalUrl) {
+      url = request.apiUmbrellaGatekeeper.originalUrl;
+    } else {
+      url = request.url;
+    }
+    var httpsUrl = request.base.replace(/^http:\/\//i, 'https://') + url;
+
+    if(mode === 'transition_return_error' || mode === 'transition_return_redirect') {
+      var transitionStartAt = request.apiUmbrellaGatekeeper.settings.require_https_transition_start_at;
+      var user = request.apiUmbrellaGatekeeper.user;
+
+      // If there is no user, or the user existed prior to the HTTPS transition
+      // starting, then continue on, allowing http.
+      if(!user || !user.created_at || user.created_at < transitionStartAt) {
+        return next();
+      }
+    }
+
+    if(mode === 'required_return_redirect' || mode === 'transition_return_redirect') {
+      // Return a 301 Moved Permanently redirect for GET requests.
+      var statusCode = 301;
+
+      // For non-GET requests, return a 307 Temporary Redirect, which instructs
+      // the request to be made again with the same method (eg, a POST should
+      // be retried as another POST). Ideally we would return a 308 Permanent
+      // Redirect for permanent semantics, but that's an experimental RFC and
+      // some libraries do something else currently with 308s (Resume
+      // Incomplete): http://stackoverflow.com/q/14144664
+      //
+      // Also for general reference, see Curl's current handling of 301, 302,
+      // and 303s: http://curl.haxx.se/docs/manpage.html#-L
+      if(request.method !== 'GET') {
+        statusCode = 307;
+      }
+
+      var headers = {
+        'Access-Control-Allow-Origin': '*',
+        'Location': httpsUrl,
+      };
+
+      var body;
+      if(request.method !== 'HEAD') {
+        body = 'Redirecting to ' + httpsUrl;
+        headers['Content-Type'] = 'text/plain';
+        headers['Content-Length'] = Buffer.byteLength(body);
+      }
+
+      response.writeHead(statusCode, headers);
+      response.end(body);
+    } else {
+      utils.errorHandler(request, response, 'https_required', {
+        httpsUrl: httpsUrl,
+      });
+    }
+  },
+});
+
+module.exports = function httpsRequirements(proxy) {
+  var middleware = new HttpsRequirements(proxy);
+
+  return function(request, response, next) {
+    middleware.handleRequest(request, response, next);
+  };
+};

--- a/lib/gatekeeper/utils.js
+++ b/lib/gatekeeper/utils.js
@@ -1,14 +1,15 @@
 'use strict';
 
-var cloneDeep = require('clone'),
+var _ = require('lodash'),
     config = require('api-umbrella-config').global(),
     csv = require('csv-string'),
     handlebars = require('handlebars'),
+    logger = require('../logger'),
     mime = require('mime'),
     Negotiator = require('negotiator'),
     url = require('url');
 
-exports.errorHandler = function(request, response, error) {
+exports.errorHandler = function(request, response, error, data) {
   var availableMediaTypes = ['application/json', 'application/xml', 'text/csv', 'text/html'];
 
   // Prefer the format from the extension given in the URL.
@@ -43,7 +44,14 @@ exports.errorHandler = function(request, response, error) {
   // introduce in multi-line templates and XML doesn't like if there's any
   // leading space before the XML declaration.
   var templateContent = settings.error_templates[format].replace(/^\s+|\s+$/g, '');
-  var data = cloneDeep(settings.error_data[error] || settings.error_data.internal_server_error);
+  var errorData = settings.error_data[error];
+  if(!errorData) {
+    errorData = settings.error_data.internal_server_error;
+    logger.error({ error_type: error }, 'Error data not found for error type: ' + error);
+  }
+  data = _.merge({
+    baseUrl: request.base,
+  }, data || {}, errorData);
 
   var prop;
   for(prop in data) {
@@ -51,7 +59,7 @@ exports.errorHandler = function(request, response, error) {
       // TODO: Templates should be precompiled. Only compile them when the
       // configuration is read-in or changed.
       var valueTemplate = handlebars.compile(data[prop], { noEscape: true });
-      data[prop] = valueTemplate({ baseUrl: request.base });
+      data[prop] = valueTemplate(data);
     } catch(e) {
     }
   }

--- a/lib/gatekeeper/worker.js
+++ b/lib/gatekeeper/worker.js
@@ -93,6 +93,7 @@ _.extend(Worker.prototype, {
       middleware.apiMatcher(),
       middleware.apiSettings(),
       middleware.apiKeyValidator(this),
+      middleware.httpsRequirements(),
       middleware.roleValdiator(this),
       middleware.ipValidator(this),
       middleware.refererValidator(this),

--- a/lib/models/api_user_schema.js
+++ b/lib/models/api_user_schema.js
@@ -11,6 +11,7 @@ module.exports = function(mongoose) {
       type: String,
       index: { unique: true },
     },
+    created_at: Date,
     first_name: String,
     last_name: String,
     email: String,

--- a/test/config/test.yml
+++ b/test/config/test.yml
@@ -12,3 +12,5 @@ apis:
     url_matches:
       - frontend_prefix: /
         backend_prefix: /
+apiSettings:
+  require_https: optional

--- a/test/server/https_requirements.js
+++ b/test/server/https_requirements.js
@@ -152,7 +152,7 @@ describe('https requirements', function() {
 
         request('http://localhost:9333' + path + '?foo=bar&hello=world', options, function(error, response, body) {
           should.not.exist(error);
-          body.should.include('https://localhost:9333' + path + '?foo=bar&hello=world');
+          body.should.include('https://localhost' + path + '?foo=bar&hello=world');
           done();
         });
       });
@@ -178,7 +178,7 @@ describe('https requirements', function() {
 
         request('http://localhost:9333' + path + '?foo=bar&hello=world', options, function(error, response) {
           should.not.exist(error);
-          response.headers['location'].should.eql('https://localhost:9333' + path + '?foo=bar&hello=world');
+          response.headers['location'].should.eql('https://localhost' + path + '?foo=bar&hello=world');
           done();
         });
       });
@@ -194,7 +194,7 @@ describe('https requirements', function() {
         request('http://localhost:9333' + path + '?foo=bar&hello=world', options, function(error, response, body) {
           should.not.exist(error);
           response.headers['content-type'].should.eql('text/plain');
-          body.should.eql('Redirecting to https://localhost:9333' + path + '?foo=bar&hello=world');
+          body.should.eql('Redirecting to https://localhost' + path + '?foo=bar&hello=world');
           parseInt(response.headers['content-length'], 10).should.eql(body.length);
           done();
         });
@@ -231,7 +231,7 @@ describe('https requirements', function() {
 
         request('http://localhost:9333' + path + '?foo=bar&hello=world', options, function(error, response, body) {
           should.not.exist(error);
-          response.headers['location'].should.eql('https://localhost:9333' + path + '?foo=bar&hello=world');
+          response.headers['location'].should.eql('https://localhost' + path + '?foo=bar&hello=world');
           body.should.eql('');
           should.not.exist(response.headers['content-type']);
           should.not.exist(response.headers['content-length']);

--- a/test/server/https_requirements.js
+++ b/test/server/https_requirements.js
@@ -1,0 +1,352 @@
+'use strict';
+
+require('../test_helper');
+
+var _ = require('lodash'),
+    Factory = require('factory-lady'),
+    request = require('request');
+
+describe('https requirements', function() {
+  shared.runServer({
+    apiSettings: {
+      require_https: 'required_return_error',
+    },
+    apis: [
+      {
+        frontend_host: 'localhost',
+        backend_host: 'example.com',
+        url_matches: [
+          {
+            frontend_prefix: '/info/default/',
+            backend_prefix: '/info/',
+          }
+        ],
+        settings: {
+          require_https: null,
+        },
+      },
+      {
+        frontend_host: 'localhost',
+        backend_host: 'example.com',
+        url_matches: [
+          {
+            frontend_prefix: '/info/required_return_error/',
+            backend_prefix: '/info/',
+          }
+        ],
+        settings: {
+          require_https: 'required_return_error',
+        },
+      },
+      {
+        frontend_host: 'localhost',
+        backend_host: 'example.com',
+        url_matches: [
+          {
+            frontend_prefix: '/info/required_return_redirect/',
+            backend_prefix: '/info/',
+          }
+        ],
+        settings: {
+          require_https: 'required_return_redirect',
+        },
+      },
+      {
+        frontend_host: 'localhost',
+        backend_host: 'example.com',
+        url_matches: [
+          {
+            frontend_prefix: '/info/transition_return_error/',
+            backend_prefix: '/info/',
+          }
+        ],
+        settings: {
+          require_https: 'transition_return_error',
+          require_https_transition_start_at: new Date(2013, 1, 1, 1, 27, 0),
+        },
+      },
+      {
+        frontend_host: 'localhost',
+        backend_host: 'example.com',
+        url_matches: [
+          {
+            frontend_prefix: '/info/transition_return_redirect/',
+            backend_prefix: '/info/',
+          }
+        ],
+        settings: {
+          require_https: 'transition_return_redirect',
+          require_https_transition_start_at: new Date(2013, 1, 1, 1, 27, 0),
+        },
+      },
+      {
+        frontend_host: 'localhost',
+        backend_host: 'example.com',
+        url_matches: [
+          {
+            frontend_prefix: '/info/optional/',
+            backend_prefix: '/info/',
+          }
+        ],
+        settings: {
+          require_https: 'optional',
+        },
+        sub_settings: [
+          {
+            http_method: 'any',
+            regex: '^/info/sub-inherit/',
+            settings: {
+              require_https: null,
+            },
+          },
+          {
+            http_method: 'any',
+            regex: '^/info/sub/',
+            settings: {
+              require_https: 'required_return_redirect',
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  function itBehavesLikeHttpsAllowed(path) {
+    describe('https request is allowed', function() {
+      shared.itBehavesLikeGatekeeperAllowed(path, {
+        followRedirect: false,
+        headers: {
+          'X-Forwarded-Proto': 'https',
+        },
+      });
+    });
+  }
+
+  function itBehavesLikeHttpAllowed(path) {
+    describe('http request is allowed', function() {
+      shared.itBehavesLikeGatekeeperAllowed(path, {
+        followRedirect: false,
+        headers: {
+          'X-Forwarded-Proto': 'http',
+        },
+      });
+    });
+  }
+
+  function itBehavesLikeHttpError(path) {
+    describe('http request returns an error', function() {
+      shared.itBehavesLikeGatekeeperBlocked(path, 400, 'HTTPS_REQUIRED', {
+        followRedirect: false,
+        headers: {
+          'X-Forwarded-Proto': 'http',
+        },
+      });
+
+      it('returns the https URL in the error message', function(done) {
+        var options = _.merge({}, this.options, {
+          followRedirect: false,
+          headers: {
+            'X-Forwarded-Proto': 'http',
+          },
+        });
+
+        request('http://localhost:9333' + path + '?foo=bar&hello=world', options, function(error, response, body) {
+          should.not.exist(error);
+          body.should.include('https://localhost:9333' + path + '?foo=bar&hello=world');
+          done();
+        });
+      });
+    });
+  }
+
+  function itBehavesLikeHttpRedirect(path) {
+    describe('http request returns a 301 redirect', function() {
+      shared.itBehavesLikeGatekeeperBlocked(path, 301, false, {
+        followRedirect: false,
+        headers: {
+          'X-Forwarded-Proto': 'http',
+        },
+      });
+
+      it('returns the https URL in the Location header', function(done) {
+        var options = _.merge({}, this.options, {
+          followRedirect: false,
+          headers: {
+            'X-Forwarded-Proto': 'http',
+          },
+        });
+
+        request('http://localhost:9333' + path + '?foo=bar&hello=world', options, function(error, response) {
+          should.not.exist(error);
+          response.headers['location'].should.eql('https://localhost:9333' + path + '?foo=bar&hello=world');
+          done();
+        });
+      });
+
+      it('returns the https URL in a plain text message body', function(done) {
+        var options = _.merge({}, this.options, {
+          followRedirect: false,
+          headers: {
+            'X-Forwarded-Proto': 'http',
+          },
+        });
+
+        request('http://localhost:9333' + path + '?foo=bar&hello=world', options, function(error, response, body) {
+          should.not.exist(error);
+          response.headers['content-type'].should.eql('text/plain');
+          body.should.eql('Redirecting to https://localhost:9333' + path + '?foo=bar&hello=world');
+          parseInt(response.headers['content-length'], 10).should.eql(body.length);
+          done();
+        });
+      });
+    });
+
+    describe('http POST request returns a 307 redirect', function() {
+      shared.itBehavesLikeGatekeeperBlocked(path, 307, false, {
+        method: 'POST',
+        followRedirect: false,
+        headers: {
+          'X-Forwarded-Proto': 'http',
+        },
+      });
+    });
+
+    describe('http HEAD request returns a 307 redirect', function() {
+      shared.itBehavesLikeGatekeeperBlocked(path, 307, false, {
+        method: 'HEAD',
+        followRedirect: false,
+        headers: {
+          'X-Forwarded-Proto': 'http',
+        },
+      });
+
+      it('returns the https URL in the header, but not in the body', function(done) {
+        var options = _.merge({}, this.options, {
+          method: 'HEAD',
+          followRedirect: false,
+          headers: {
+            'X-Forwarded-Proto': 'http',
+          },
+        });
+
+        request('http://localhost:9333' + path + '?foo=bar&hello=world', options, function(error, response, body) {
+          should.not.exist(error);
+          response.headers['location'].should.eql('https://localhost:9333' + path + '?foo=bar&hello=world');
+          body.should.eql('');
+          should.not.exist(response.headers['content-type']);
+          should.not.exist(response.headers['content-length']);
+          done();
+        });
+      });
+
+    });
+  }
+
+  describe('required_return_error', function() {
+    itBehavesLikeHttpsAllowed('/info/required_return_error/');
+    itBehavesLikeHttpError('/info/required_return_error/');
+  });
+
+  describe('required_return_redirect', function() {
+    itBehavesLikeHttpsAllowed('/info/required_return_redirect/');
+    itBehavesLikeHttpRedirect('/info/required_return_redirect/');
+  });
+
+  describe('transition_return_error', function() {
+    itBehavesLikeHttpsAllowed('/info/transition_return_error/');
+
+    describe('api user created before the transition start', function() {
+      beforeEach(function createApiUser(done) {
+        Factory.create('api_user', { created_at: new Date(2013, 1, 1, 1, 26, 59) }, function(user) {
+          this.user = user;
+          this.apiKey = user.api_key;
+          this.options = {
+            headers: {
+              'X-Api-Key': this.apiKey,
+            }
+          };
+          done();
+        }.bind(this));
+      });
+
+      itBehavesLikeHttpAllowed('/info/transition_return_error/');
+    });
+
+    describe('api user created on or after the transition start', function() {
+      beforeEach(function createApiUser(done) {
+        Factory.create('api_user', { created_at: new Date(2013, 1, 1, 1, 27, 0) }, function(user) {
+          this.user = user;
+          this.apiKey = user.api_key;
+          this.options = {
+            headers: {
+              'X-Api-Key': this.apiKey,
+            }
+          };
+          done();
+        }.bind(this));
+      });
+
+      itBehavesLikeHttpError('/info/transition_return_error/');
+    });
+  });
+
+  describe('transition_return_redirect', function() {
+    itBehavesLikeHttpsAllowed('/info/transition_return_redirect/');
+
+    describe('api user created before the transition start', function() {
+      beforeEach(function createApiUser(done) {
+        Factory.create('api_user', { created_at: new Date(2013, 1, 1, 1, 26, 59) }, function(user) {
+          this.user = user;
+          this.apiKey = user.api_key;
+          this.options = {
+            headers: {
+              'X-Api-Key': this.apiKey,
+            }
+          };
+          done();
+        }.bind(this));
+      });
+
+      itBehavesLikeHttpAllowed('/info/transition_return_redirect/');
+    });
+
+    describe('api user created on or after the transition start', function() {
+      beforeEach(function createApiUser(done) {
+        Factory.create('api_user', { created_at: new Date(2013, 1, 1, 1, 27, 0) }, function(user) {
+          this.user = user;
+          this.apiKey = user.api_key;
+          this.options = {
+            headers: {
+              'X-Api-Key': this.apiKey,
+            }
+          };
+          done();
+        }.bind(this));
+      });
+
+      itBehavesLikeHttpRedirect('/info/transition_return_redirect/');
+    });
+  });
+
+  describe('optional', function() {
+    itBehavesLikeHttpsAllowed('/info/optional/');
+    itBehavesLikeHttpAllowed('/info/optional/');
+  });
+
+  describe('inherit/undefined defaults to required_return_error mode', function() {
+    itBehavesLikeHttpsAllowed('/info/default/');
+    itBehavesLikeHttpError('/info/default/');
+  });
+
+  describe('sub-url settings', function() {
+    describe('inherit/undefined defaults to the parent mode', function() {
+      itBehavesLikeHttpsAllowed('/info/optional/sub-inherit/');
+      itBehavesLikeHttpAllowed('/info/optional/sub-inherit/');
+    });
+
+    describe('sub setting overrides the mode of the parent', function() {
+      itBehavesLikeHttpsAllowed('/info/optional/sub/');
+      itBehavesLikeHttpRedirect('/info/optional/sub/');
+    });
+  });
+});

--- a/test/support/server_shared_examples.js
+++ b/test/support/server_shared_examples.js
@@ -81,59 +81,75 @@ _.merge(global.shared, {
 
   itBehavesLikeGatekeeperBlocked: function(path, statusCode, errorCode, options) {
     it('doesn\'t call the target app', function(done) {
-      request(shared.buildRequestOptions(path, this.apiKey, options), function() {
+      request(shared.buildRequestOptions(path, this.apiKey, options), function(error) {
+        should.not.exist(error);
         backendCalled.should.eql(false);
         done();
       });
     });
 
-    it('returns a blocked status code and error code', function(done) {
-      request(shared.buildRequestOptions(path, this.apiKey, options), function(error, response, body) {
+    it('returns a ' + statusCode + ' status code', function(done) {
+      request(shared.buildRequestOptions(path, this.apiKey, options), function(error, response) {
+        should.not.exist(error);
         response.statusCode.should.eql(statusCode);
-        body.should.include(errorCode);
         done();
       });
     });
 
     it('allows errors to be accessed from any origin via CORS', function(done) {
       request(shared.buildRequestOptions(path, this.apiKey, options), function(error, response) {
+        should.not.exist(error);
         response.headers['access-control-allow-origin'].should.eql('*');
         done();
       });
     });
 
-    describe('formatted error responses', function() {
-      it('returns a JSON error response', function(done) {
-        request(shared.buildRequestOptions(path + '.json', this.apiKey, options), function(error, response, body) {
-          var data = JSON.parse(body);
-          data.error.code.should.eql(errorCode);
+    if(errorCode) {
+      it('returns a blocked error code', function(done) {
+        request(shared.buildRequestOptions(path, this.apiKey, options), function(error, response, body) {
+          should.not.exist(error);
+          body.should.include(errorCode);
           done();
         });
       });
 
-      it('returns an XML error response', function(done) {
-        request(shared.buildRequestOptions(path + '.xml', this.apiKey, options), function(error, response, body) {
-          xml2js.parseString(body, function(error, data) {
-            data.response.error[0].code[0].should.eql(errorCode);
+      describe('formatted error responses', function() {
+        it('returns a JSON error response', function(done) {
+          request(shared.buildRequestOptions(path + '.json', this.apiKey, options), function(error, response, body) {
+            should.not.exist(error);
+            var data = JSON.parse(body);
+            data.error.code.should.eql(errorCode);
             done();
           });
         });
-      });
 
-      it('returns CSV error response', function(done) {
-        request(shared.buildRequestOptions(path + '.csv', this.apiKey, options), function(error, response, body) {
-          csv().from.string(body).to.array(function(data) {
-            data[1][0].should.eql(errorCode);
-            done();
+        it('returns an XML error response', function(done) {
+          request(shared.buildRequestOptions(path + '.xml', this.apiKey, options), function(error, response, body) {
+            should.not.exist(error);
+            xml2js.parseString(body, function(error, data) {
+              data.response.error[0].code[0].should.eql(errorCode);
+              done();
+            });
+          });
+        });
+
+        it('returns CSV error response', function(done) {
+          request(shared.buildRequestOptions(path + '.csv', this.apiKey, options), function(error, response, body) {
+            should.not.exist(error);
+            csv().from.string(body).to.array(function(data) {
+              data[1][0].should.eql(errorCode);
+              done();
+            });
           });
         });
       });
-    });
+    }
   },
 
   itBehavesLikeGatekeeperAllowed: function(path, options) {
     it('calls the target app', function(done) {
-      request(shared.buildRequestOptions(path, this.apiKey, options), function() {
+      request(shared.buildRequestOptions(path, this.apiKey, options), function(error) {
+        should.not.exist(error);
         backendCalled.should.eql(true);
         done();
       });
@@ -141,6 +157,7 @@ _.merge(global.shared, {
 
     it('returns a successful response', function(done) {
       request(shared.buildRequestOptions(path, this.apiKey, options), function(error, response) {
+        should.not.exist(error);
         response.statusCode.should.eql(200);
         done();
       });


### PR DESCRIPTION
Now each API backend can choose to require HTTPS with either an error message instructing the user to use HTTPS or a redirect. There's also support for a "transition" mode where existing API keys can continue calling the API via HTTP, but all new api keys must use HTTPS.

Related to https://github.com/18F/api.data.gov/issues/34