### PR TITLE
Account for different formatted query params in the error handling code

### DIFF
--- a/lib/gatekeeper/utils.js
+++ b/lib/gatekeeper/utils.js
@@ -18,7 +18,7 @@ exports.errorHandler = function(request, response, error, data) {
 
   // Fall back to a GET parameter named "format".
   if(mimeType === 'application/octet-stream' && request.query.format) {
-    mimeType = mime.lookup(request.query.format);
+    mimeType = mime.lookup(request.query.format.toString());
   }
 
   // Failing that, use Accept header negotiation.

--- a/test/server/formatted_errors.js
+++ b/test/server/formatted_errors.js
@@ -65,6 +65,37 @@ describe('formatted error responses', function() {
         done();
       });
     });
+
+    it('gracefully handles query param encoding, format[]=xml', function(done) {
+      request.get('http://localhost:9333/hello?format[]=xml', function(error, response, body) {
+        body.should.include('<code>API_KEY_MISSING</code>');
+        done();
+      });
+    });
+
+    it('gracefully handles query param encoding, format=xml&format=csv', function(done) {
+      request.get('http://localhost:9333/hello?format=xml&format=csv', function(error, response, body) {
+        var data = JSON.parse(body);
+        data.error.code.should.eql('API_KEY_MISSING');
+        done();
+      });
+    });
+
+    it('gracefully handles query params encoding, format[key]=value', function(done) {
+      request.get('http://localhost:9333/hello?format[key]=value', function(error, response, body) {
+        var data = JSON.parse(body);
+        data.error.code.should.eql('API_KEY_MISSING');
+        done();
+      });
+    });
+
+    it('gracefully handles query params encoding, format[]=', function(done) {
+      request.get('http://localhost:9333/hello?format[]=', function(error, response, body) {
+        var data = JSON.parse(body);
+        data.error.code.should.eql('API_KEY_MISSING');
+        done();
+      });
+    });
   });
 
   describe('data variables', function() {


### PR DESCRIPTION
"Sanitizes" the query by turning it in to a string (very complicated, you see). Tests should cover a few previously problematic scenarios.