### PR TITLE
Wildcard subdomain support

### DIFF
--- a/lib/gatekeeper/middleware/api_matcher.js
+++ b/lib/gatekeeper/middleware/api_matcher.js
@@ -3,6 +3,7 @@
 var _ = require('lodash'),
     cloneDeep = require('clone'),
     config = require('api-umbrella-config').global(),
+    escapeRegexp = require('escape-regexp'),
     handlebars = require('handlebars'),
     querystring = require('querystring'),
     RoutePattern = require('route-pattern'),
@@ -25,6 +26,7 @@ _.extend(ApiMatcher.prototype, {
     apis = apis.concat(config.get('apis') || []);
 
     this.apisByHost = {};
+    this.wildcardApis = [];
     for(var i = 0; i < apis.length; i++) {
       var api = cloneDeep(apis[i]);
 
@@ -81,6 +83,11 @@ _.extend(ApiMatcher.prototype, {
       }
 
       this.apisByHost[api.frontend_host].push(api);
+
+      if(api.frontend_host && api.frontend_host[0] === '*') {
+        api._frontend_host_regex = new RegExp('.*' + escapeRegexp(api.frontend_host.slice(1)));
+        this.wildcardApis.push(api);
+      }
     }
   },
 
@@ -159,8 +166,11 @@ _.extend(ApiMatcher.prototype, {
       apis = [];
     }
 
-    if(this.apisByHost['*']) {
-      apis = apis.concat(this.apisByHost['*']);
+    for(var i = 0, len = this.wildcardApis.length; i < len; i++) {
+      var api = this.wildcardApis[i];
+      if(api._frontend_host_regex.test(host)) {
+        apis.push(api);
+      }
     }
 
     return apis;

--- a/test/server/request_rewriting.js
+++ b/test/server/request_rewriting.js
@@ -358,8 +358,18 @@ describe('request rewriting', function() {
           backend_host: null,
           url_matches: [
             {
-              frontend_prefix: '/info/none',
-              backend_prefix: '/info/none',
+              frontend_prefix: '/info/none-null/',
+              backend_prefix: '/info/none-null/',
+            }
+          ],
+        },
+        {
+          frontend_host: 'localhost',
+          backend_host: '',
+          url_matches: [
+            {
+              frontend_prefix: '/info/none-empty-string/',
+              backend_prefix: '/info/none-empty-string/',
             }
           ],
         },
@@ -404,8 +414,17 @@ describe('request rewriting', function() {
       }.bind(this));
     });
 
-    it('leaves the host header untouched when a backend replacement is not present', function(done) {
-      request.get('http://localhost:9333/info/none?api_key=' + this.apiKey, function(error, response, body) {
+    it('leaves the host header untouched when a backend replacement is null', function(done) {
+      request.get('http://localhost:9333/info/none-null/?api_key=' + this.apiKey, function(error, response, body) {
+        var data = JSON.parse(body);
+        data.headers.host.should.eql('localhost:9333');
+
+        done();
+      }.bind(this));
+    });
+
+    it('leaves the host header untouched when a backend replacement is an empty string', function(done) {
+      request.get('http://localhost:9333/info/none-empty-string/?api_key=' + this.apiKey, function(error, response, body) {
         var data = JSON.parse(body);
         data.headers.host.should.eql('localhost:9333');
 


### PR DESCRIPTION
This adds support for an API Backend to be configured to listen on a wildcard subdomain. We previously supported a special `*` total wildcard hostname, but this allows for listening on more specific subdomains so a single API backend can serve up all the requests to `*.example.com` (so this would match both `foo.example.com` and `bar.example.com`).