### PR TITLE
Add ability to have wildcard backend hostnames

### DIFF
--- a/lib/gatekeeper/middleware/api_matcher.js
+++ b/lib/gatekeeper/middleware/api_matcher.js
@@ -85,7 +85,7 @@ _.extend(ApiMatcher.prototype, {
       this.apisByHost[api.frontend_host].push(api);
 
       if(api.frontend_host && api.frontend_host[0] === '*') {
-        api._frontend_host_regex = new RegExp('.*' + escapeRegexp(api.frontend_host.slice(1)));
+        api._frontend_host_regex = new RegExp('(.*)' + escapeRegexp(api.frontend_host.slice(1)));
         this.wildcardApis.push(api);
       }
     }
@@ -168,7 +168,9 @@ _.extend(ApiMatcher.prototype, {
 
     for(var i = 0, len = this.wildcardApis.length; i < len; i++) {
       var api = this.wildcardApis[i];
-      if(api._frontend_host_regex.test(host)) {
+      var hostMatches = host.match(api._frontend_host_regex);
+      if(hostMatches) {
+        api._frontend_host_wildcard_match = hostMatches[1];
         apis.push(api);
       }
     }

--- a/lib/gatekeeper/middleware/rewrite_request.js
+++ b/lib/gatekeeper/middleware/rewrite_request.js
@@ -110,7 +110,12 @@ _.extend(RewriteRequest.prototype, {
   setHost: function(request) {
     var host = request.apiUmbrellaGatekeeper.matchedApi.backend_host;
     if(host) {
-      request.headers.Host = host;
+      var wildcardMatch = request.apiUmbrellaGatekeeper.matchedApi._frontend_host_wildcard_match;
+      if(typeof wildcardMatch === 'string') {
+        request.headers.Host = host.replace(/^\*/, wildcardMatch);
+      } else {
+        request.headers.Host = host;
+      }
     }
   },
 

--- a/test/server/api_matcher.js
+++ b/test/server/api_matcher.js
@@ -112,6 +112,17 @@ describe('ApiUmbrellaGatekeper', function() {
             ]
           },
           {
+            'frontend_host': '*wildcard-backend.foo',
+            'backend_host': '*example.com',
+            '_id': 'wildcard-backend',
+            'url_matches': [
+              {
+                'frontend_prefix': '/info/wildcard-backend/',
+                'backend_prefix': '/info/wildcard-backend/'
+              }
+            ]
+          },
+          {
             'frontend_host': 'default-host-config.example.com',
             'backend_host': 'example.com',
             '_id': 'default-host-config',
@@ -216,6 +227,7 @@ describe('ApiUmbrellaGatekeper', function() {
         request.get(opts, function(error, response, body) {
           var data = JSON.parse(body);
           data.headers['x-api-umbrella-backend-id'].should.eql('wildcard');
+          data.headers['host'].should.eql('example.com');
           done();
         });
       });
@@ -230,6 +242,7 @@ describe('ApiUmbrellaGatekeper', function() {
         request.get(opts, function(error, response, body) {
           var data = JSON.parse(body);
           data.headers['x-api-umbrella-backend-id'].should.eql('wildcard');
+          data.headers['host'].should.eql('example.com');
           done();
         });
       });
@@ -245,6 +258,7 @@ describe('ApiUmbrellaGatekeper', function() {
           request.get(opts, function(error, response, body) {
             var data = JSON.parse(body);
             data.headers['x-api-umbrella-backend-id'].should.eql('wildcard-with-dot-subdomain');
+            data.headers['host'].should.eql('example.com');
             done();
           });
         });
@@ -267,6 +281,7 @@ describe('ApiUmbrellaGatekeper', function() {
           request.get(opts, function(error, response, body) {
             var data = JSON.parse(body);
             data.headers['x-api-umbrella-backend-id'].should.eql('wildcard-without-dot-subdomain');
+            data.headers['host'].should.eql('example.com');
             done();
           });
         });
@@ -281,6 +296,7 @@ describe('ApiUmbrellaGatekeper', function() {
           request.get(opts, function(error, response, body) {
             var data = JSON.parse(body);
             data.headers['x-api-umbrella-backend-id'].should.eql('wildcard-without-dot-subdomain');
+            data.headers['host'].should.eql('example.com');
             done();
           });
         });
@@ -290,6 +306,51 @@ describe('ApiUmbrellaGatekeper', function() {
             headers: {
               'Host': 'foo.wild-without-dot-subdomainXfoo',
             },
+          });
+        });
+
+        it('replaces wildcard subdomains in backend hosts', function(done) {
+          var opts = shared.buildRequestOptions('/info/wildcard-backend/', this.apiKey, {
+            headers: {
+              'Host': 'foo.wildcard-backend.foo',
+            },
+          });
+
+          request.get(opts, function(error, response, body) {
+            var data = JSON.parse(body);
+            data.headers['x-api-umbrella-backend-id'].should.eql('wildcard-backend');
+            data.headers['host'].should.eql('foo.example.com');
+            done();
+          });
+        });
+
+        it('replaces wildcard subdomains multiple levels deep in backend hosts', function(done) {
+          var opts = shared.buildRequestOptions('/info/wildcard-backend/', this.apiKey, {
+            headers: {
+              'Host': 'foo.bar.wildcard-backend.foo',
+            },
+          });
+
+          request.get(opts, function(error, response, body) {
+            var data = JSON.parse(body);
+            data.headers['x-api-umbrella-backend-id'].should.eql('wildcard-backend');
+            data.headers['host'].should.eql('foo.bar.example.com');
+            done();
+          });
+        });
+
+        it('replaces wildcard backend hosts with nothing if accessing the root', function(done) {
+          var opts = shared.buildRequestOptions('/info/wildcard-backend/', this.apiKey, {
+            headers: {
+              'Host': 'wildcard-backend.foo',
+            },
+          });
+
+          request.get(opts, function(error, response, body) {
+            var data = JSON.parse(body);
+            data.headers['x-api-umbrella-backend-id'].should.eql('wildcard-backend');
+            data.headers['host'].should.eql('example.com');
+            done();
           });
         });
       });


### PR DESCRIPTION
This extends the wildcard hostname support added in https://github.com/NREL/api-umbrella-gatekeeper/pull/13 Now the backend host can be rewritten to also contain the matched piece of the wildcard in the frontend host (previously the backend host was either static or an empty string, in which case the frontend host was passed through verbatim).

The backend host just uses the same wildcard `*` syntax for the replacement value. Now with a frontend host like `*.example.com` and a backend host of `*.api-backend.foo`, a request to `penguin.example.com` would be rewritten into `penguin.api-backend.foo`.