### PR TITLE
Partial solution to bucketing api rates

### DIFF
--- a/lib/gatekeeper/middleware/api_key_validator.js
+++ b/lib/gatekeeper/middleware/api_key_validator.js
@@ -119,22 +119,30 @@ _.extend(ApiKeyValidatorRequest.prototype, {
     this.request.apiUmbrellaGatekeeper.user = user;
 
     if(user.settings) {
+      var settingsCopy = cloneDeep(user.settings),
+          request_backend = this.request.apiUmbrellaGatekeeper.matchedApi.backend_host;
+      // We should remove any rate_limits which are for separate domains as we
+      // don't want them to apply here
+      settingsCopy.rate_limits = _.filter(settingsCopy.rate_limits || [], function(rateLimit) {
+        return !rateLimit.backend_host || rateLimit.backend_host === request_backend;
+      });
+
       // Delete a "null" value for a user-specific rate limit mode, since
       // we don't want that to overwrite the API-specific settings during
       // the settings merge.
-      if(user.settings.rate_limit_mode === null) {
-        delete user.settings.rate_limit_mode;
+      if(settingsCopy.rate_limit_mode === null) {
+        delete settingsCopy.rate_limit_mode;
       }
 
       // Similarly, if the user has an empty custom rate limits array
       // assigned to it, be sure that doesn't take precedence over the
       // default rate limits.
-      if(user.settings.rate_limits && user.settings.rate_limits.length === 0) {
-        delete user.settings.rate_limits;
+      if(settingsCopy.rate_limits && settingsCopy.rate_limits.length === 0) {
+        delete settingsCopy.rate_limits;
       }
 
       request.apiUmbrellaGatekeeper.originalUserSettings = cloneDeep(user.settings);
-      mergeOverwriteArrays(request.apiUmbrellaGatekeeper.settings, user.settings);
+      mergeOverwriteArrays(request.apiUmbrellaGatekeeper.settings, settingsCopy);
     }
 
     this.next();

--- a/test/server/rate_limiting.js
+++ b/test/server/rate_limiting.js
@@ -878,6 +878,28 @@ describe('ApiUmbrellaGatekeper', function() {
 
     describe('user specific limits', function() {
       shared.runServer({
+        apis: [
+          {
+            frontend_host: 'localhost',
+            backend_host: 'example.com:8080',
+            url_matches: [
+              {
+                frontend_prefix: '/info/port',
+                backend_prefix: '/info/port'
+              }
+            ]
+          },
+          {
+            frontend_host: 'localhost',
+            backend_host: 'example.com',
+            url_matches: [
+              {
+                frontend_prefix: '/',
+                backend_prefix: '/'
+              }
+            ]
+          }
+        ],
         apiSettings: {
           rate_limits: [
             {
@@ -930,6 +952,7 @@ describe('ApiUmbrellaGatekeper', function() {
                   limit: 10,
                   distributed: true,
                   response_headers: true,
+                  backend_host: 'example.com',
                 }
               ]
             }
@@ -957,6 +980,9 @@ describe('ApiUmbrellaGatekeper', function() {
             }.bind(this));
           }.bind(this));
         });
+
+        // Different backend host has different limits
+        itBehavesLikeApiKeyRateLimits('/info/port', 5);
       });
     });
   });


### PR DESCRIPTION
This adds the ability for custom-to-user rate limits to apply only to certain backends. This is a partial solution to https://github.com/18F/api.data.gov/issues/124 : a more lenient rate limit for one api won't override a stricter rate limit for another.

This is a meandering step towards the bucket idea discussed in that issue; instead of a general solution, this focuses on using the backend host as bucket key. I figure, we will need some indicator of which named bucket to count toward for each request. We can swap out `backend_host` for whatever that indicator becomes later.

Note that this will require some changes in `-web` (to set the `backend_host` when creating the custom  limit). Further, this does not alleviate the global counting problem; it addresses only on the custom-limits-per-domain problem.