### PR TITLE
Better error handling for if error data is unexpectedly not an object.

### DIFF
--- a/lib/gatekeeper/utils.js
+++ b/lib/gatekeeper/utils.js
@@ -45,7 +45,7 @@ exports.errorHandler = function(request, response, error, data) {
   // leading space before the XML declaration.
   var templateContent = settings.error_templates[format].replace(/^\s+|\s+$/g, '');
   var errorData = settings.error_data[error];
-  if(!errorData) {
+  if(!errorData || !_.isPlainObject(errorData)) {
     errorData = settings.error_data.internal_server_error;
     logger.error({ error_type: error }, 'Error data not found for error type: ' + error);
   }


### PR DESCRIPTION
Related to it being possible to enter invalid error data (but valid YAML) via the web UI: https://github.com/NREL/api-umbrella/issues/153

In these cases, we will now return the default internal server error, which at least prevents bad error responses without an HTTP status code at all, which could really throw some clients for a tizzy.