### PR TITLE
API rate buckets, defaulting to the frontend host

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -15,6 +15,8 @@ entry in `url_matches`
     requests will hit.
 * `apis.backend_host` - The domain name (possibly including port) which
     gatekeeper will proxy. This might be considered sensitive
+* `apis.rate_limit_bucket_name` - This provides an explicit bucket for api
+    rate limits to count against. Defaults to the `frontend_host`.
 * `apis.url_matches` - An array of path mappings between the frontend path and
     the backend path (see below)
 * `apis.settings` - A configuration object which contains various settings for

--- a/lib/gatekeeper/middleware/api_matcher.js
+++ b/lib/gatekeeper/middleware/api_matcher.js
@@ -82,6 +82,10 @@ _.extend(ApiMatcher.prototype, {
         }
       }
 
+      if (!api.rate_limit_bucket_name) {
+        api.rate_limit_bucket_name = api.frontend_host;
+      }
+
       this.apisByHost[api.frontend_host].push(api);
 
       if(api.frontend_host && api.frontend_host[0] === '*') {

--- a/lib/gatekeeper/middleware/rate_limit.js
+++ b/lib/gatekeeper/middleware/rate_limit.js
@@ -150,6 +150,8 @@ _.extend(RateLimitRequestTimeWindow.prototype, {
         this.key += this.request.ip;
         break;
       }
+
+      this.key += ':' + this.request.apiUmbrellaGatekeeper.matchedApi.rate_limit_bucket_name;
     }
 
     return this.key;


### PR DESCRIPTION
Different API paths can be tagged with different bucket names. These bucket names will be used when determining how to count rate limit requests. By default, these rate limits will be bucketed by frontend host name.

We'll need a corresponding pull request to the admin interface to allow this bucket to be defined explicitly.

Relates to https://github.com/18F/api.data.gov/issues/124