### PR TITLE
Move rate_limit_bucket_name into an API setting

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -15,8 +15,6 @@ entry in `url_matches`
     requests will hit.
 * `apis.backend_host` - The domain name (possibly including port) which
     gatekeeper will proxy. This might be considered sensitive
-* `apis.rate_limit_bucket_name` - This provides an explicit bucket for api
-    rate limits to count against. Defaults to the `frontend_host`.
 * `apis.url_matches` - An array of path mappings between the frontend path and
     the backend path (see below)
 * `apis.settings` - A configuration object which contains various settings for
@@ -34,6 +32,9 @@ of this as a prefix-only search-and-replace.
 These are the default settings to use across APIs. Individual APIs can
 override them or append to them via `apis.settings`.
 
+* `apiSettings.rate_limit_bucket_name` - This provides an explicit bucket for api
+    rate limits to count against. Defaults to the `frontend_host` associated
+    with the api.
 * `apiSettings.rate_limits` - An array of configurations for how to limit the default
     user (individual API keys might have their own restrictions/permissions).
     See below for details on these configurations

--- a/lib/gatekeeper/middleware/api_matcher.js
+++ b/lib/gatekeeper/middleware/api_matcher.js
@@ -82,10 +82,6 @@ _.extend(ApiMatcher.prototype, {
         }
       }
 
-      if (!api.rate_limit_bucket_name) {
-        api.rate_limit_bucket_name = api.frontend_host;
-      }
-
       this.apisByHost[api.frontend_host].push(api);
 
       if(api.frontend_host && (api.frontend_host === '*' || api.frontend_host[0] === '.' || api.frontend_host.slice(0, 2) === '*.')) {

--- a/lib/gatekeeper/middleware/rate_limit.js
+++ b/lib/gatekeeper/middleware/rate_limit.js
@@ -135,23 +135,26 @@ _.extend(RateLimitRequestTimeWindow.prototype, {
 
   getKey: function() {
     if(!this.key) {
-      var limitBy = this.timeWindow.options.limit_by;
+      var limitBy = this.timeWindow.options.limit_by,
+          gatekeeper = this.request.apiUmbrellaGatekeeper,
+          api = gatekeeper.matchedApi;
 
-      if(!this.request.apiUmbrellaGatekeeper.user || this.request.apiUmbrellaGatekeeper.user.throttle_by_ip) {
+      if(!gatekeeper.user || gatekeeper.user.throttle_by_ip) {
         limitBy = 'ip';
       }
 
       this.key = this.timeWindow.prefix + ':';
       switch(limitBy) {
       case 'apiKey':
-        this.key += this.request.apiUmbrellaGatekeeper.apiKey;
+        this.key += gatekeeper.apiKey;
         break;
       case 'ip':
         this.key += this.request.ip;
         break;
       }
 
-      this.key += ':' + this.request.apiUmbrellaGatekeeper.matchedApi.rate_limit_bucket_name;
+      this.key += ':';
+      this.key += api.settings.rate_limit_bucket_name || api.frontend_host;
     }
 
     return this.key;

--- a/test/server/rate_limiting.js
+++ b/test/server/rate_limiting.js
@@ -815,13 +815,15 @@ describe('ApiUmbrellaGatekeper', function() {
           {
             frontend_host: 'localhost',
             backend_host: 'example.com',
-            rate_limit_bucket_name: 'different',
             url_matches: [
               {
                 frontend_prefix: '/different-bucket/',
                 backend_prefix: '/',
               }
-            ]
+            ],
+            settings: {
+              rate_limit_bucket_name: 'different',
+            }
           },
           {
             frontend_host: '*',


### PR DESCRIPTION
Per https://github.com/NREL/api-umbrella-web/pull/22#issuecomment-126170179, this moves the `rate_limit_bucket_name` key into the `settings` per api. This also moves the logic to default to `frontend_host` out of the API matcher and into the Rate Limit middleware, per the corresponding Lua change.